### PR TITLE
Update textlint

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-  '*.md': ['textlint --rulesdir textlint/rules'],
+  linters: {
+    '*.md': ['textlint --rulesdir textlint/rules'],
+  },
+  ignore: ['textlint/fixtures/*'],
 };

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "prettier": "yarn format:source && yarn format:examples",
     "prettier:diff": "yarn nit:source && yarn nit:examples",
     "reset": "rimraf ./.cache",
-    "test:textlint": "mocha textlint/tests/**/*.spec.js"
+    "test:textlint": "mocha textlint/tests/**/*.spec.js",
+    "test:textlint-cli": "textlint --rulesdir textlint/rules textlint/fixtures/*.md --format stylish"
   },
   "devDependencies": {
     "@babel/preset-flow": "^7.0.0",

--- a/textlint/fixtures/terminology.md
+++ b/textlint/fixtures/terminology.md
@@ -1,0 +1,10 @@
+# Terminology Fixtures
+
+> Markdown for verifying textlint CLI result
+
+- 메서드
+- 서드파티와 써드파티와 써드 파티
+- 예제
+- 응용프로그램과 어플리케이션
+- 함수형 컴포넌트
+- 라이프사이클

--- a/textlint/rules/terminology.js
+++ b/textlint/rules/terminology.js
@@ -42,14 +42,16 @@ const g = args => args.map(arg => new RegExp(arg, 'g'));
  */
 const terms = [
   {
+    // http://www.korean.go.kr/front/onlineQna/onlineQnaView.do?mn_id=61&qna_seq=11976
     value: '메서드',
     expressions: [/메소드/, /메쏘드/],
     message: 'method는 메서드가 올바른 표현입니다',
   },
   {
-    value: '서드파티',
-    expressions: [/써드파티/],
-    message: 'third party는 서드파티가 올바른 표현입니다',
+    // https://opendict.korean.go.kr/dictionary/view?sense_no=1251028
+    value: '서드 파티',
+    expressions: [/서드파티/, /써드파티/, /써드 파티/],
+    message: 'third party는 서드 파티가 올바른 표현입니다',
   },
   {
     value: '예시',

--- a/textlint/rules/terminology.js
+++ b/textlint/rules/terminology.js
@@ -51,4 +51,24 @@ const terms = [
     expressions: [/써드파티/],
     message: 'third party는 서드파티가 올바른 표현입니다',
   },
+  {
+    value: '예시',
+    expressions: [/예제/],
+    message: 'example은 예시로 표현합니다.',
+  },
+  {
+    value: '애플리케이션',
+    expressions: [/응용프로그램/, /어플리케이션/],
+    message: 'application은 애플리케이션으로 표현합니다.',
+  },
+  {
+    value: '함수 컴포넌트',
+    expressions: [/함수형 컴포넌트/],
+    message: 'function(al) component는 함수 컴포넌트로 표현합니다.',
+  },
+  {
+    value: '생명주기',
+    expressions: [/라이프사이클/],
+    message: 'life cycle은 생명주기로 표현합니다.',
+  },
 ].map(term => ({...term, expressions: g(term.expressions)}));

--- a/textlint/tests/terminology.spec.js
+++ b/textlint/tests/terminology.spec.js
@@ -6,7 +6,7 @@ const tester = new TextLintTester();
 tester.run('terminology', rule, {
   valid: [
     '메서드',
-    '서드파티',
+    '서드 파티',
     '예시',
     '애플리케이션',
     '함수 컴포넌트',
@@ -18,8 +18,8 @@ tester.run('terminology', rule, {
       errors: [{index: 14}, {index: 19}, {index: 24}],
     },
     {
-      text: '써드파티',
-      errors: [{index: 0}],
+      text: '서드파티와 써드파티와 써드 파티',
+      errors: [{index: 0}, {index: 6}, {index: 12}],
     },
     {
       text: '예제',

--- a/textlint/tests/terminology.spec.js
+++ b/textlint/tests/terminology.spec.js
@@ -4,7 +4,14 @@ const rule = require('../rules/terminology');
 const tester = new TextLintTester();
 
 tester.run('terminology', rule, {
-  valid: ['메서드', '서드파티'],
+  valid: [
+    '메서드',
+    '서드파티',
+    '예시',
+    '애플리케이션',
+    '함수 컴포넌트',
+    '생명주기',
+  ],
   invalid: [
     {
       text: '한 문장에 연속하는 용어 메소드와 메소드와 메쏘드를 테스트합니다.',
@@ -12,6 +19,22 @@ tester.run('terminology', rule, {
     },
     {
       text: '써드파티',
+      errors: [{index: 0}],
+    },
+    {
+      text: '예제',
+      errors: [{index: 0}],
+    },
+    {
+      text: '응용프로그램과 어플리케이션',
+      errors: [{index: 0}, {index: 8}],
+    },
+    {
+      text: '함수형 컴포넌트',
+      errors: [{index: 0}],
+    },
+    {
+      text: '라이프사이클',
       errors: [{index: 0}],
     },
   ],


### PR DESCRIPTION
This pull request adds some terminology ("예시", "애플리케이션", "함수 컴포넌트", "생명주기")
and I fix "서드파티" to "서드 파티" based on [국립국어원 우리말샘](https://opendict.korean.go.kr/dictionary/view?sense_no=1251028). 

For one-time textlint cli testing, I add `test:textlint-cli`. Please check this out :)