### PR TITLE
fix typo

### DIFF
--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -34,7 +34,7 @@ string type
 
 > 주의
 >
-> v17부터 `e.persiste()`는 `SyntheticEvent`가 더 이상 [풀링](/docs/legacy-event-pooling.html)되지 않기 때문에 아무런 동작을 하지 않습니다.
+> v17부터 `e.persist()`는 `SyntheticEvent`가 더 이상 [풀링](/docs/legacy-event-pooling.html)되지 않기 때문에 아무런 동작을 하지 않습니다.
 
 > 주의
 >


### PR DESCRIPTION
fixed typo
from `e.persiste()` to `e.persist()`  

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [ ] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [ ] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [ ] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [ ] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
