### PR TITLE
Remove duplicate content and add link

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -128,9 +128,7 @@ const MyComponent = React.memo(function MyComponent(props) {
 
 당신의 컴포넌트가 동일한 props로 동일한 결과를 렌더링해낸다면, `React.memo`를 호출하고 결과를 메모이징(Memoizing)하도록 래핑하여 경우에 따라 성능 향상을 누릴 수 있습니다. 즉, React는 컴포넌트를 렌더링하지 않고 마지막으로 렌더링된 결과를 재사용합니다.
 
-`React.memo` only checks for prop changes. If your function component wrapped in `React.memo` has a [`useState`](/docs/hooks-state.html) or [`useContext`](/docs/hooks-reference.html#usecontext) Hook in its implementation, it will still rerender when state or context change.
-
-`React.memo`는 props 변화에만 영향을 줍니다. `React.memo`로 감싸진 함수 컴포넌트 구현에 `useState` 또는 `useContext` 훅을 사용한다면, 여전히 state나 context가 변할 때 다시 렌더링됩니다.
+`React.memo`는 props 변화에만 영향을 줍니다. `React.memo`로 감싸진 함수 컴포넌트 구현에 [`useState`](/docs/hooks-state.html) 또는 [`useContext`](/docs/hooks-reference.html#usecontext) 훅을 사용한다면, 여전히 state나 context가 변할 때 다시 렌더링됩니다.
 
 props가 갖는 복잡한 객체에 대하여 얕은 비교만을 수행하는 것이 기본 동작입니다. 다른 비교 동작을 원한다면, 두 번째 인자로 별도의 비교 함수를 제공하면 됩니다.
 


### PR DESCRIPTION
React.memo() 설명에 영어로 된 설명이 중복되어 영어 부분을 삭제하고 한글 부분에 원문과 같이 useState, useContext에 대한 링크를 추가했습니다 😊

## Before
![image](https://user-images.githubusercontent.com/37496919/106079084-e5c6eb80-6157-11eb-996a-01cce8bc3bae.png)

## After
![image](https://user-images.githubusercontent.com/37496919/106079308-5241ea80-6158-11eb-8e7d-ac926e5d283e.png)


- remove duplicate english content
- add link(useState/ useContext) to korean content

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [ ] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [ ] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [ ] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [ ] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
