### PR TITLE
단어 수정 및 누락된 문장, 단어 추가 ,Conditional Rendering

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -150,7 +150,7 @@ ReactDOM.render(
 
 JavaScript에서 `true && expression`은 항상 `expression`으로 평가되고 `false && expression`은 항상 `false`로 평가됩니다.
 
-따라서 `&&` 뒤의 엘리먼트는 조건이 `true`일때 출력이 됩니다. 조건이 `false`라면 React는 무시합니다.
+따라서 `&&` 뒤의 엘리먼트는 조건이 `true`일때 출력이 됩니다. 조건이 `false`라면 React는 무시하고 건너뜁니다.
 
 falsy 표현식을 반환하면 `&&` 뒤에 있는 표현식은 건너뛰지만 falsy 표현식이 반환된다는 것에 주의해주세요. 아래 예시에서, `<div>0</div>`이 render 메서드에서 반환됩니다.
 

--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -152,7 +152,7 @@ JavaScript에서 `true && expression`은 항상 `expression`으로 평가되고 
 
 따라서 `&&` 뒤의 엘리먼트는 조건이 `true`일때 출력이 됩니다. 조건이 `false`라면 React는 무시하고 건너뜁니다.
 
-falsy 표현식을 반환하면 `&&` 뒤에 있는 표현식은 건너뛰지만 falsy 표현식이 반환된다는 것에 주의해주세요. 아래 예시에서, `<div>0</div>`이 render 메서드에서 반환됩니다.
+falsy 표현식을 반환하면 여전히 `&&` 뒤에 있는 표현식은 건너뛰지만 falsy 표현식이 반환된다는 것에 주의해주세요. 아래 예시에서, `<div>0</div>`이 render 메서드에서 반환됩니다.
 
 ```javascript{2,5}
 render() {

--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -152,7 +152,7 @@ JavaScript에서 `true && expression`은 항상 `expression`으로 평가되고 
 
 따라서 `&&` 뒤의 엘리먼트는 조건이 `true`일때 출력이 됩니다. 조건이 `false`라면 React는 무시합니다.
 
-false로 평가될 수 있는 표현식을 반환하면 `&&` 뒤에 있는 표현식은 건너뛰지만 false로 평가될 수 있는 표현식이 반환된다는 것에 주의해주세요. 아래 예시에서, `<div>0</div>`이 render 메서드에서 반환됩니다.
+falsy 표현식을 반환하면 `&&` 뒤에 있는 표현식은 건너뛰지만 falsy 표현식이 반환된다는 것에 주의해주세요. 아래 예시에서, `<div>0</div>`이 render 메서드에서 반환됩니다.
 
 ```javascript{2,5}
 render() {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

(1) skip it. 문장이 생략되어서 추가했습니다.

- 원문
  - If it is false, React will ignore and skip it.
- AS IS
  - 따라서 `&&` 뒤의 엘리먼트는 조건이 `true`일때 출력이 됩니다. 조건이 `false`라면 React는 무시합니다.
- TO BE
  - 따라서 `&&` 뒤의 엘리먼트는 조건이 `true`일때 출력이 됩니다. 조건이 `false`라면 React는 **무시하고 건너뜁니다.**

---

(2) 기존 `false로 평가될 수 있는 표현식을 반환`가 가독성이 떨어집니다. 이에 2가지 대안을 제안합니다. 또한, 누락된 still 추가했습니다.

1. 원문의 `falsy expression`에서 `falsy` 단어 표현 사용.
2. `false로 평가될 수 있는 표현식을 반환`을 `거짓으로 평가될 수 있는 표현식을 반환`으로 수정.

- 원문
  - Note that returning a falsy expression will still cause the element after && to be skipped but will return the falsy expression.
- AS IS
  - false로 평가될 수 있는 표현식을 반환하면 `&&` 뒤에 있는 표현식은 건너뛰지만 false로 평가될 수 있는 표현식이 반환된다는 것에 주의해주세요.
- TO BE
  - **falsy** 표현식을 반환하면 **여전히** `&&` 뒤에 있는 표현식은 건너뛰지만 **falsy** 표현식이 반환된다는 것에 주의해주세요.

## Progress

- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [x] 리뷰 반영 (Resolve reviews)
