### PR TITLE
fix: translation

### DIFF
--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -296,7 +296,7 @@ state를 끌어오면 코드가 장황해지고, 이로 인하여 컴포넌트�
 getSnapshotBeforeUpdate(prevProps, prevState)
 ```
 
-`getSnapshotBeforeUpdate()`는 가장 마지막으로 렌더링된 결과가 DOM 등에 반영되었을 때에 호출됩니다. 이 메서드를 사용하면 컴포넌트가 DOM으로부터 스크롤 위치 등과 같은 정보를 이후 변경되기 전에 얻을 수 있습니다. 이 생명주기 메서드가 반환하는 값은 `componentDidUpdate()`에 인자로 전달됩니다.
+`getSnapshotBeforeUpdate()`는 가장 마지막으로 렌더링된 결과가 DOM 등에 반영되기 전에 호출됩니다. 이 메서드를 사용하면 컴포넌트가 DOM으로부터 스크롤 위치 등과 같은 정보를 이후 변경되기 전에 얻을 수 있습니다. 이 생명주기 메서드가 반환하는 값은 `componentDidUpdate()`에 인자로 전달됩니다.
 
 이 메서드에 대한 사용례는 흔하지 않지만, 채팅 화면처럼 스크롤 위치를 따로 처리하는 작업이 필요한 UI 등을 생각해볼 수 있습니다.
 


### PR DESCRIPTION
- english version
```
getSnapshotBeforeUpdate() is invoked right before the most recently rendered output is committed to e.g. the DOM
```

- korean version
```
getSnapshotBeforeUpdate()는 가장 마지막으로 렌더링된 결과가 DOM 등에 반영되었을 때에 호출됩니다.
```

`반영되었을 때에` -> `반영되기 전에` 로 수정하였습니다.

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [ ] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [ ] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [ ] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [ ] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
