### PR TITLE
fix: Hooks FAQ 문서 'miss' 단어 번역 변경 

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -289,7 +289,7 @@ function Box() {
 
 이는 state 변수를 업데이트할 때 그 값을 *대체*하기 때문입니다. 이것은 업데이트된 필드를 객체에 *병합*하는 class의 `this.setState`와 다릅니다.
 
-자동 병합을 놓친 경우 개체 state 업데이트를 병합하는 커스텀 `useLegacyState` Hook을 작성할 수 있습니다. 그러나, **함께 변경되는 값에 따라 state를 여러 state 변수로 분할하는 것을 추천합니다.**
+자동 병합이 그리운 경우 개체 state 업데이트를 병합하는 커스텀 `useLegacyState` Hook을 작성할 수 있습니다. 그러나, **함께 변경되는 값에 따라 state를 여러 state 변수로 분할하는 것을 추천합니다.**
 
 예를 들어 컴포넌트 state를 `position` 및 `size` 객체로 분할하고 병합할 필요 없이 항상 `position`을 대체 할 수 있습니다.
 


### PR DESCRIPTION
 ' A miss B'는 A가 B를 놓치다로도 해석될 수 있지만  이 상황에서는 A가 B를 그리워  하다로 해석하는 것이 더 의미상으로 적절하고 전달이 잘됩니다.  state merging에 대한 설명 중 'A miss B'의 번역을 A가 B를 그리워하다로 번역을 바꾸었습니다.


## Progress

- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
