### PR TITLE
코드 분할 문서 내용 수정

### DIFF
--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -76,7 +76,7 @@ Webpack이 이 구문을 만나게 되면 앱의 코드를 분할합니다. Crea
 
 [코드 분할 가이드](https://webpack.js.org/guides/code-splitting/)를 참조하세요. Webpack 설정은 [가이드](https://gist.github.com/gaearon/ca6e803f5c604d37468b0091d9959269)에 있습니다.
 
-[Babel](http://babeljs.io/)을 사용할 때는 Babel이 동적 import를 인식할 수 있지만 변환하지는 않도록 합니다. 이를 위해 [babel-plugin-syntax-dynamic-import](https://yarnpkg.com/en/package/babel-plugin-syntax-dynamic-import)를 사용하세요.
+[Babel](http://babeljs.io/)을 사용할 때는 Babel이 동적 import를 인식할 수 있지만 변환하지는 않도록 합니다. 이를 위해 [@babel/plugin-syntax-dynamic-import](https://classic.yarnpkg.com/en/package/@babel/plugin-syntax-dynamic-import)를 사용하세요.
 
 ## `React.lazy` {#reactlazy}
 


### PR DESCRIPTION

<img width="962" alt="image" src="https://user-images.githubusercontent.com/38802280/169475364-de1dca66-23a7-4157-879d-2087dad786b7.png">


코드 분할 관련 내용을 읽다가 해당 내용에서 babel 관련된 deprecated된 패키지를 사용하는 문장이 있어 해당 패키지 이름과, url을 수정하였습니다. (공식 문서에서는 업데이트 되어 있더라구요)

deprecated된 패키지: https://github.com/webpack-contrib/babel-minify-webpack-plugin

혹시 더 좋은 커밋명이 있다면, 추천해주시면 감사하겠습니다. 🙇 

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
