### PR TITLE
Translated a sentence into Korean

### DIFF
--- a/content/docs/rendering-elements.md
+++ b/content/docs/rendering-elements.md
@@ -34,7 +34,7 @@ HTML 파일 어딘가에 `<div>`가 있다고 가정해 봅시다.
 
 React로 구현된 애플리케이션은 일반적으로 하나의 루트 DOM 노드가 있습니다. React를 기존 앱에 통합하려는 경우 원하는 만큼 많은 수의 독립된 루트 DOM 노드가 있을 수 있습니다.
 
-To render a React element, first pass the DOM element to [`ReactDOM.createRoot()`](/docs/react-dom-client.html#createroot), then pass the React element to `root.render()`:
+React 엘리먼트를 렌더링 하기 위해서는 우선 DOM 엘리먼트를 [`ReactDOM.createRoot()`](/docs/react-dom-client.html#createroot)에 전달한 다음, React 엘리먼트를 `root.render()`에 전달해야 합니다. 
 
 `embed:rendering-elements/render-an-element.js`
 


### PR DESCRIPTION
To render a React element, first pass the DOM element to ReactDOM.createRoot(), then pass the React element to root.render(): 
-> React 엘리먼트를 렌더링 하기 위해서는 우선 DOM 엘리먼트를 ReactDOM.createRoot()에 전달한 다음, React 엘리먼트를 root.render()에 전달해야 합니다.