### PR TITLE
Fix: Line-broken Korean text in header links

### DIFF
--- a/src/components/LayoutHeader/HeaderLink.js
+++ b/src/components/LayoutHeader/HeaderLink.js
@@ -39,6 +39,7 @@ const style = {
   },
 
   [media.size('xsmall')]: {
+    whiteSpace: 'nowrap',
     paddingLeft: 8,
     paddingRight: 8,
   },


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Fix wrapped Korean text of HeaderLink  component inside navigation bar of [reactjs offical website](https://ko.reactjs.org/)
- style `whitespace` to be `nowrap`
Below is the before & after picture

리액트 공식 문서를 모바일에서 보면 헤더의 텍스트 줄 바꿈 현상이 생겨나 style 수정하였습니다.
아래는 전후 비교 사진입니다.

|  **BEFORE** |  **AFTER**  |
|---|---|
|  <img src="https://user-images.githubusercontent.com/13115713/197377593-1b564a94-317c-4f81-81df-40cdc6292ca1.gif" alt="ko.react.org-header-before" width="300"/>  |  <img src="https://user-images.githubusercontent.com/13115713/197377597-ae0cdb87-9423-4e7c-b966-c4941785fa04.gif" alt="ko.react.org-header-before" width="300"/> |
| As you see, text '자습서' is displayed as below with line-breaks. '자\n습\n서' | As you see, text '자습서' is displayed as it is. |

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [ ] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [ ] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [ ] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [ ] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
