### PR TITLE
용어 규칙에 맞는 맞춤법으로 수정

### DIFF
--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -156,7 +156,7 @@ function withSubscription(WrappedComponent, selectData) {
     }
 
     render() {
-      // ... 래핑된 컴포넌트를 새로운 데이터로 랜더링 합니다!
+      // ... 래핑된 컴포넌트를 새로운 데이터로 렌더링 합니다!
       // 컴포넌트에 추가로 props를 내려주는 것에 주목하세요.
       return <WrappedComponent data={this.state.data} {...this.props} />;
     }

--- a/content/docs/implementation-notes.md
+++ b/content/docs/implementation-notes.md
@@ -47,7 +47,7 @@ console.log(<App />);
 
 `App`이 함수라면, 재조정자는 렌더링 엘리먼트를 가져오기 위해 `App(props)`를 호출합니다.
 
-`App`이 class면, 재조정자는 `App`을 `new App(props)`로 인스턴스화 하고, `componentWillMount()` 생명주기 메서드를 호출한 후, `render()` 메서드를 호출하여 랜더링 엘리먼트를 가져오게 할 것입니다.
+`App`이 class면, 재조정자는 `App`을 `new App(props)`로 인스턴스화 하고, `componentWillMount()` 생명주기 메서드를 호출한 후, `render()` 메서드를 호출하여 렌더링 엘리먼트를 가져오게 할 것입니다.
 
 어느 경우든, 재조정자는 `App`이 렌더링 되는 엘리먼트를 학습하게 됩니다.
 

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -350,7 +350,7 @@ render() {
 <MyComponent>{'foo'}</MyComponent>
 ```
 
-이는 임의의 길이를 가진 JSX 표현식의 배열을 랜더링 할 때 종종 유용하게 사용됩니다. 아래의 예시는 HTML 배열로 랜더됩니다.
+이는 임의의 길이를 가진 JSX 표현식의 배열을 렌더링 할 때 종종 유용하게 사용됩니다. 아래의 예시는 HTML 배열로 렌더됩니다.
 
 ```js{2,9}
 function Item(props) {

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -52,7 +52,7 @@ MyComponent.propTypes = {
   optionalString: PropTypes.string,
   optionalSymbol: PropTypes.symbol,
 
-  // 랜더링 될 수 있는 것들은 다음과 같습니다.
+  // 렌더링 될 수 있는 것들은 다음과 같습니다.
   // 숫자(numbers), 문자(strings), 엘리먼트(elements), 또는 이러한 타입들(types)을 포함하고 있는 배열(array) (혹은 배열의 fragment)
   optionalNode: PropTypes.node,
 


### PR DESCRIPTION
용어 통일을 위해 맞춤법에 맞지 않는 단어가 확인되어 수정했습니다🙂
랜더 -> 렌더
## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [ ] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [ ] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
